### PR TITLE
Fixed missing host. Fixed timeout.

### DIFF
--- a/APIBlueprintImporter.coffee
+++ b/APIBlueprintImporter.coffee
@@ -9,11 +9,14 @@ APIBlueprintImporter = ->
   @importBlueprint = (context, blueprint) ->
     ast = blueprint["ast"]
     metadata = ast["metadata"]
-    baseHost = ""
+    baseHost = null
 
     for metadata in ast["metadata"]
       if metadata["name"] == "HOST"
           baseHost = metadata["value"]
+
+    if not baseHost
+        baseHost = "http://my-host.com"
 
     # TODO make real base host
     resourceGroups = ast["resourceGroups"]
@@ -171,7 +174,7 @@ APIBlueprintImporter = ->
     http_request = new NetworkHTTPRequest()
     http_request.requestUrl = "https://api.apiblueprint.org/parser"
     http_request.requestMethod = "POST"
-    http_request.requestTimeout = 3600
+    http_request.requestTimeout = 3600000
     http_request.requestBody = string
     http_request.setRequestHeader "Content-Type", "text/vnd.apiblueprint+markdown; version=1A; charset=utf-8"
     http_request.setRequestHeader "Accept", "application/vnd.apiblueprint.parseresult.raw+json"

--- a/APIBlueprintImporter.js
+++ b/APIBlueprintImporter.js
@@ -7,13 +7,16 @@
       var ast, baseHost, metadata, resourceGroup, resourceGroups, _i, _j, _len, _len1, _ref, _results;
       ast = blueprint["ast"];
       metadata = ast["metadata"];
-      baseHost = "";
+      baseHost = null;
       _ref = ast["metadata"];
       for (_i = 0, _len = _ref.length; _i < _len; _i++) {
         metadata = _ref[_i];
         if (metadata["name"] === "HOST") {
           baseHost = metadata["value"];
         }
+      }
+      if (!baseHost) {
+        baseHost = "http://my-host.com";
       }
       resourceGroups = ast["resourceGroups"];
       _results = [];
@@ -124,7 +127,7 @@
       http_request = new NetworkHTTPRequest();
       http_request.requestUrl = "https://api.apiblueprint.org/parser";
       http_request.requestMethod = "POST";
-      http_request.requestTimeout = 3600;
+      http_request.requestTimeout = 3600000;
       http_request.requestBody = string;
       http_request.setRequestHeader("Content-Type", "text/vnd.apiblueprint+markdown; version=1A; charset=utf-8");
       http_request.setRequestHeader("Accept", "application/vnd.apiblueprint.parseresult.raw+json");


### PR DESCRIPTION
@kylef Just noticed that when no base host is defined, it creates invalid URLs in Paw (as URLs in Paw need to have their base: protocol + host). So it adds a default host name (not perfect at all). Future versions of Paw will allow to configure Environment Variables or even prompt users for choice, so we can improve it later.

Also, timeouts are in milliseconds, to match standard JavaScript libraries.
