### PR TITLE
[Cakefile] Expose test output

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -12,7 +12,7 @@ build_dir = "#{ build_root_dir }/#{ identifier }"
 
 # compile CoffeeScript
 build_coffee = (callback) ->
-    coffee = spawn 'coffee', ['-c', '-o', build_dir, file]
+    coffee = spawn './node_modules/coffee-script/bin/coffee', ['-c', '-o', build_dir, file]
     coffee.stderr.on 'data', (data) ->
         process.stderr.write data.toString()
     coffee.stdout.on 'data', (data) ->

--- a/Cakefile
+++ b/Cakefile
@@ -75,8 +75,8 @@ task 'build', ->
 
 task 'test', ->
   exec './node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register test.coffee', (err, output) ->
-    throw err if err
     console.log output
+    throw err if err
 
 task 'install', ->
     build () ->

--- a/Cakefile
+++ b/Cakefile
@@ -12,7 +12,7 @@ build_dir = "#{ build_root_dir }/#{ identifier }"
 
 # compile CoffeeScript
 build_coffee = (callback) ->
-    coffee = spawn './node_modules/coffee-script/bin/coffee', ['-c', '-o', build_dir, file]
+    coffee = spawn './node_modules/.bin/coffee', ['-c', '-o', build_dir, file]
     coffee.stderr.on 'data', (data) ->
         process.stderr.write data.toString()
     coffee.stdout.on 'data', (data) ->
@@ -74,7 +74,7 @@ task 'build', ->
     build()
 
 task 'test', ->
-  exec './node_modules/mocha/bin/mocha --compilers coffee:coffee-script/register test.coffee', (err, output) ->
+  exec './node_modules/.bin/mocha --compilers coffee:coffee-script/register test.coffee', (err, output) ->
     console.log output
     throw err if err
 


### PR DESCRIPTION
This fixes two problems:
- Use coffee-script directly from node_modules, since the dependency may not be installed on the system. In my case it's only installed as a dependency for this.
- Show test failure output before throwing exception, otherwise you can't see the output.