### PR TITLE
Don't nest unnamed resource groups, resources and examples

### DIFF
--- a/test.coffee
+++ b/test.coffee
@@ -171,7 +171,7 @@ describe 'API Blueprint Importer Paw Extension', ->
           "name": "Awesome example",
         }
         importer = new APIBlueprintImporter()
-        @request = importer.importExample(@context, "GET", "http://api.acme.com/message", example)
+        @request = importer.importExample(@context, null, "GET", "http://api.acme.com/message", example)
 
       it 'should create a request with a name', ->
         assert.equal(@request.name, "Awesome example")
@@ -210,7 +210,7 @@ describe 'API Blueprint Importer Paw Extension', ->
           ],
         }
         importer = new APIBlueprintImporter()
-        @requestGroup = importer.importExample(@context, "GET", "http://api.acme.com/message", example)
+        @requestGroup = importer.importExample(@context, null, "GET", "http://api.acme.com/message", example)
         @request = @requestGroup.children[0]
 
       it 'should create a request group with a name', ->
@@ -221,24 +221,6 @@ describe 'API Blueprint Importer Paw Extension', ->
 
       it 'should create a request with a name', ->
         assert.equal(@request.name, "Update Plain Text Message")
-
-    it 'should use the description as a name if the name is ommitted', ->
-      example = {
-        "name": "",
-        "description": "Description!",
-      }
-      importer = new APIBlueprintImporter()
-      request = importer.importExample(@context, "GET", "http://api.acme.com/message", example)
-      assert.equal(request.name, "Description!")
-
-    it 'should use the name "example" if the name and description is ommitted', ->
-      example = {
-        "name": "",
-        "description": "",
-      }
-      importer = new APIBlueprintImporter()
-      request = importer.importExample(@context, "GET", "http://api.acme.com/message", example)
-      assert.equal(request.name, "Example")
 
   describe 'when importing an example request', ->
     before ->
@@ -255,7 +237,7 @@ describe 'API Blueprint Importer Paw Extension', ->
       }
 
       importer = new APIBlueprintImporter()
-      @request = importer.importExampleRequest(@context, "GET", "http://api.acme.com/message", exampleRequest)
+      @request = importer.importExampleRequest(@context, null, "GET", "http://api.acme.com/message", exampleRequest)
 
     it 'should have a name', ->
       assert.equal(@request.name, "Update Plain Text Message")


### PR DESCRIPTION
Currently the Paw plugin keeps the API Blueprint AST structure intact when importing within the Paw hierarchy. Unfortunately this provides poor UX when there are unnamed resource groups and unnamed examples (most examples are usually unnamed).

Let's take a look at an example, here is the previous behaviour of the Polls API example blueprint:

![screen shot 2015-08-29 at 14 42 17](https://cloud.githubusercontent.com/assets/44164/9564437/2ac56d52-4e5c-11e5-9626-72b9bf6cf894.png)

There are various annoyances in this example:

- There is an "Unnamed" resource group, which results in an unnecessary group within Paw
- None of the examples are named so they are all called "Example"
- There is only a single example in these cases, so there is no need to create a group for the single element. In this case we can just create the request with the name of the action when there is no example name.

Here is how it looks afterwards:

![screen shot 2015-08-29 at 14 32 56](https://cloud.githubusercontent.com/assets/44164/9564436/2528441e-4e5c-11e5-9862-4f80992b27dd.png)

![screen shot 2015-08-29 at 15 15 31](https://cloud.githubusercontent.com/assets/44164/9564584/da2e3a72-4e60-11e5-8535-42c8ac8f50f5.png)

Closes #8