### PR TITLE
Support Paw's new canImport API

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -778,6 +778,12 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "dev": true
     },
+    "deckardcain": {
+      "version": "0.3.3",
+      "from": "deckardcain@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/deckardcain/-/deckardcain-0.3.3.tgz",
+      "dev": true
+    },
     "deep-eql": {
       "version": "0.1.3",
       "from": "deep-eql@>=0.1.3 <0.2.0",
@@ -819,6 +825,12 @@
       "version": "1.1.7",
       "from": "domain-browser@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "dev": true
+    },
+    "drafter": {
+      "version": "1.2.0",
+      "from": "drafter@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/drafter/-/drafter-1.2.0.tgz",
       "dev": true
     },
     "drafter.js": {
@@ -935,6 +947,26 @@
       "from": "fs.realpath@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "dev": true
+    },
+    "fury-adapter-apib-parser": {
+      "version": "0.6.1",
+      "from": "fury-adapter-apib-parser@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/fury-adapter-apib-parser/-/fury-adapter-apib-parser-0.6.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "babel-runtime": {
+          "version": "5.8.38",
+          "from": "babel-runtime@>=5.8.20 <6.0.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
+          "dev": true
+        },
+        "core-js": {
+          "version": "1.2.7",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "dev": true
+        }
+      }
     },
     "get-caller-file": {
       "version": "1.0.2",

--- a/src/APIBlueprintImporter.js
+++ b/src/APIBlueprintImporter.js
@@ -1,4 +1,5 @@
 import {Fury} from 'fury';
+import {detect} from 'fury-adapter-apib-parser';
 import {parseSync} from 'drafter.js';
 import APIElementImporter from './APIElementImporter.js'
 
@@ -9,6 +10,16 @@ export default class APIBlueprintImporter {
 
   constructor() {
     this.fury = new Fury();
+  }
+
+  canImport(context, items) {
+    for (const item of items) {
+      if (detect(item.content)) {
+        return true
+      }
+    }
+
+    return false;
   }
 
   importString(context, string) {


### PR DESCRIPTION
This means Paw can determine which extension can handle the given documents. Here's how importing worked before:
![before](https://cloud.githubusercontent.com/assets/44164/22368551/f614abc6-e47e-11e6-99a1-2b617e852a5b.gif)
And after:
![after](https://cloud.githubusercontent.com/assets/44164/22368552/f70121c2-e47e-11e6-8836-f8c7530aac2b.gif)