### PR TITLE
Allow user to supply base host

### DIFF
--- a/src/APIBlueprintImporter.js
+++ b/src/APIBlueprintImporter.js
@@ -7,6 +7,9 @@ import APIElementImporter from './APIElementImporter.js'
 export default class APIBlueprintImporter {
   static identifier = 'io.apiary.PawExtensions.APIBlueprintImporter';
   static title = 'API Blueprint Importer';
+  static inputs = [
+    InputField("host", "Base HOST", "String", {placeholder: "https://example.com"}),
+  ];
 
   constructor() {
     this.fury = new Fury();
@@ -22,11 +25,16 @@ export default class APIBlueprintImporter {
     return false;
   }
 
-  importString(context, string) {
-    const parseResult = this.fury.load(parseSync(string));
-    const importer = new APIElementImporter(context);
-    importer.importAPI(parseResult.api);
-    console.log('Imported');
+  import(context, items, options) {
+    const defaultHost = options.inputs['host'];
+
+    for (const item of items) {
+      console.log('Importing Item');
+      const parseResult = this.fury.load(parseSync(item.content));
+      const importer = new APIElementImporter(context, defaultHost);
+      importer.importAPI(parseResult.api);
+    }
+
     return true;
   }
 }

--- a/src/APIElementImporter.js
+++ b/src/APIElementImporter.js
@@ -1,7 +1,7 @@
 export default class APIElementImporter {
-  constructor(context) {
+  constructor(context, defaultHostname) {
     this.context = context;
-    this.base = 'https://example.com';
+    this.base = defaultHostname || 'https://example.com';
   }
 
   importAPI(api) {


### PR DESCRIPTION
This pull request makes use of [Paw's new inputs API](https://paw.cloud/docs/extensions/input-fields) to supply our own inputs such as a default base host.

This allows a user to override to specify the hostname to use when constructing URLs from the API Blueprint if HOST is not defined.

![custom-host](https://cloud.githubusercontent.com/assets/44164/22370737/d2e9c9ae-e48a-11e6-8e03-a83545017a41.gif)

Closes #6