### PR TITLE
Use fury.parse over depending on drafter.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "chai": "3.4.1",
     "coffee-loader": "^0.7.2",
     "coffee-script": "^1.12.2",
-    "drafter.js": "^2.6.3",
     "fury": "^2.3.0",
     "fury-adapter-apib-parser": "^0.6.1",
     "glob": "^7.0.5",

--- a/src/APIBlueprintImporter.js
+++ b/src/APIBlueprintImporter.js
@@ -1,7 +1,18 @@
 import {Fury} from 'fury';
-import {detect} from 'fury-adapter-apib-parser';
-import {parseSync} from 'drafter.js';
+import APIBlueprintParser from 'fury-adapter-apib-parser';
 import APIElementImporter from './APIElementImporter.js'
+
+function promisify(func, thisArg) {
+  return (...args) => new Promise((resolve, reject) => {
+    func.bind(thisArg)(...args, (err, result) => {
+      if (result) {
+        resolve(result);
+      } else {
+        reject(err);
+      }
+    });
+  });
+}
 
 @registerImporter
 export default class APIBlueprintImporter {
@@ -13,11 +24,12 @@ export default class APIBlueprintImporter {
 
   constructor() {
     this.fury = new Fury();
+    this.fury.use(APIBlueprintParser);
   }
 
   canImport(context, items) {
     for (const item of items) {
-      if (detect(item.content)) {
+      if (APIBlueprintParser.detect(item.content)) {
         return true
       }
     }
@@ -25,12 +37,15 @@ export default class APIBlueprintImporter {
     return false;
   }
 
-  import(context, items, options) {
+  async import(context, items, options) {
     const defaultHost = options.inputs['host'];
+
+    // FIXME remove promisify when https://github.com/apiaryio/api-elements.js/issues/37 is live
+    const parse = promisify(this.fury.parse, this.fury);
 
     for (const item of items) {
       console.log('Importing Item');
-      const parseResult = this.fury.load(parseSync(item.content));
+      const parseResult = await parse({ source: item.content, mediaType: 'text/vnd.apiblueprint' });
       const importer = new APIElementImporter(context, defaultHost);
       importer.importAPI(parseResult.api);
     }


### PR DESCRIPTION
drafter.js was used for the sync API, as Paw now supports returning promises we can use async/await with Fury.

Removing drafter.js simplifies package management as the dependency is also pulled in via fury-adapter-apib-parser.