### PR TITLE
Update readme wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,31 +3,30 @@ Paw API Blueprint Importer Extension
 
 [![Build Status](http://img.shields.io/travis/apiaryio/Paw-APIBlueprintImporter/master.svg?style=flat)](https://travis-ci.org/apiaryio/Paw-APIBlueprintImporter)
 
-This extension depends on a pre-released version of Paw and is not yet ready
-for public consumption.
-
 ### Installation
 
 The [Paw extension](https://luckymarmot.com/paw/extensions/APIBlueprintImporter) can be installed from the [Paw extensions page](https://luckymarmot.com/paw/extensions/APIBlueprintImporter).
 
-#### Development Instructions
+#### Development Instructions
 
-If you would like to develop the extension, you have follow these steps to get a development environment setup.
+If you would like to develop the extension, the following steps can be used to
+setup a development environment setup. You will need [Paw](https://paw.cloud/)
+installed.
 
 ##### Clone
 
 First of all, clone this repository in any convenient location (e.g `~/Desktop`).
 
 ```bash
-$ git clone https://github.com/apiaryio/Paw-APIBlueprintImporter
+$ git clone https://github.com/apiaryio/Paw-APIBlueprintImporter.git
 ```
 
 ##### Prerequisites
 
-Install `npm` if needed (e.g. below using [Homebrew](http://brew.sh/)):
+Install `node` if needed (e.g. below using [Homebrew](http://brew.sh/)):
 
 ```bash
-$ brew install npm
+$ brew install node
 ```
 
 Install dependencies using `npm`:
@@ -38,7 +37,7 @@ $ npm install
 
 ##### Development Installation
 
-During development, build the `.js` script using:
+During development, build the Paw extension using:
 
 ```bash
 $ npm run build


### PR DESCRIPTION
The readme is a little stale, it mentions pre-release of Paw is required (which hasn't been case in years).

There was also some unicode whitespace which caused rendering issue:

![Screenshot 2019-06-05 at 11 52 00](https://user-images.githubusercontent.com/44164/58951173-5bfb2b00-8788-11e9-92c3-443399e9e0c2.png)
