### PR TITLE
Expand URI Templates in generated URLs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,6 +3080,11 @@
         "create-hmac": "^1.1.2"
       }
     },
+    "pct-encode": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pct-encode/-/pct-encode-1.0.2.tgz",
+      "integrity": "sha1-uZt7BE1r18OeSDmnqAEirXUVyqU="
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -3592,6 +3597,14 @@
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true
+    },
+    "uri-template": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uri-template/-/uri-template-1.0.1.tgz",
+      "integrity": "sha1-FKklo35Nk/diVDKqEWsF5Qyuga0=",
+      "requires": {
+        "pct-encode": "~1.0.0"
+      }
     },
     "url": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "dependencies": {
     "babel-plugin-transform-flow-strip-types": "",
     "babel-polyfill": "",
-    "babel-runtime": ""
+    "babel-runtime": "",
+    "uri-template": "^1.0.1"
   },
   "devDependencies": {
     "babel-core": "^6.22.1",

--- a/src/APIElementImporter.js
+++ b/src/APIElementImporter.js
@@ -1,3 +1,5 @@
+const uritemplate = require('uri-template');
+
 // Takes elements as arguments and returns the value of the first
 // defined element (for example, skipping undefined elements)
 // Last argument is the default value when all elements are undefined
@@ -90,7 +92,19 @@ export default class APIElementImporter {
     console.log('Importing Transaction');
 
     const request = transaction.request;
-    const url = this.createAbsoluteURL(coalesceElementValue(request.href, transition.href, resource.href, '/unknown'));
+
+    const href = coalesceElementValue(request.href, transition.href, resource.href, '/unknown');
+    const hrefVariables = request.attributes.get('hrefVariables') || transition.hrefVariables || resource.hrefVariables;
+
+    let toExpand = {};
+    if (hrefVariables) {
+      toExpand = hrefVariables.valueOf();
+    }
+
+    const template = uritemplate.parse(href);
+    const expandedPath = template.expand(toExpand);
+    const url = this.createAbsoluteURL(expandedPath);
+
     const pawRequest = this.context.createRequest(coalesceElementValue(request.title, transition.title, 'Transaction'), request.method.toValue(), url);
 
     if (request.headers) {

--- a/test/fixtures/requests.json
+++ b/test/fixtures/requests.json
@@ -9,13 +9,13 @@
             {
               "name": "With Limits",
               "method": "POST",
-              "url": "https://example.com/test{?limit}",
+              "url": "https://example.com/test?limit=5",
               "headers": {}
             },
             {
               "name": "Without Limits",
               "method": "POST",
-              "url": "https://example.com/test{?limit}",
+              "url": "https://example.com/test?limit=0",
               "headers": {}
             }
           ]
@@ -28,13 +28,13 @@
         {
           "name": "With Limits",
           "method": "POST",
-          "url": "https://example.com/test{?limit}",
+          "url": "https://example.com/test?limit=5",
           "headers": {}
         },
         {
           "name": "Without Limits",
           "method": "POST",
-          "url": "https://example.com/test{?limit}",
+          "url": "https://example.com/test?limit=0",
           "headers": {}
         }
       ]
@@ -42,13 +42,13 @@
     {
       "name": "With Limits",
       "method": "POST",
-      "url": "https://example.com/test{?limit}",
+      "url": "https://example.com/test?limit=5",
       "headers": {}
     },
     {
       "name": "Without Limits",
       "method": "POST",
-      "url": "https://example.com/test{?limit}",
+      "url": "https://example.com/test?limit=0",
       "headers": {}
     }
   ]


### PR DESCRIPTION
Paw is a HTTP client which does not understand URI Templates which resulted in 1) loss of information (the values of parameters are discarded) and 2) rendering of the URL and parameters to be incorrect as the URL was split.

This can be solved by expanding the URI Template with the user provided parameter values (sample, default etc).

Before:

(note also value is missing)

![Screenshot 2019-06-07 at 11 43 02](https://user-images.githubusercontent.com/44164/59098879-80d2d800-8919-11e9-9566-789fc1519ec4.png)

After:

![Screenshot 2019-06-07 at 11 43 28](https://user-images.githubusercontent.com/44164/59098876-80d2d800-8919-11e9-8985-a50246e85569.png)

Fixes #15